### PR TITLE
Remove explict version number from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "wikimedia/gpglib",
     "description": "A wrapper around GPG for stateless operations.",
-    "version": "0.2.1",
     "keywords": ["gpg", "encryption"],
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Composer/Packagist typically handles versioning with git tags rather
than explicit version numbers. Since this project is managed in VCS that
supports tagging we should avoid the fragility of hand managed version
numbers. See https://getcomposer.org/doc/04-schema.md#version for
further details.