### PR TITLE
Allow any psr/log 1.* version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "source": "https://github.com/wikimedia/php-gpglib"
     },
     "require": {
-        "psr/log": "1.0.0"
+        "psr/log": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",


### PR DESCRIPTION
Expand the requirement for use of psr/log to any 1.x version.

Closes #4